### PR TITLE
Add /chat-ui frontend for testing AI replies

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,46 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template_string
 
 app = Flask(__name__)
 
 @app.route('/')
 def hello():
     return 'Hello from your AI Flask server!'
+
+@app.route('/chat-ui')
+def chat_ui():
+    return render_template_string('''
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Simple AI Chat</title>
+            <style>
+                body { font-family: sans-serif; padding: 2em; }
+                input, button { padding: 0.5em; font-size: 1em; }
+                #response { margin-top: 1em; color: green; }
+            </style>
+        </head>
+        <body>
+            <h2>Fake AI Chat</h2>
+            <input type="text" id="message" placeholder="Say something..." />
+            <button onclick="sendMessage()">Send</button>
+            <div id="response"></div>
+
+            <script>
+                async function sendMessage() {
+                    const msg = document.getElementById('message').value;
+                    const res = await fetch('/chat', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ message: msg })
+                    });
+                    const data = await res.json();
+                    document.getElementById('response').textContent = data.response;
+                }
+            </script>
+        </body>
+        </html>
+    ''')
+
 
 @app.route('/chat', methods=['POST'])
 def chat():


### PR DESCRIPTION
### What This PR Adds
- Adds a `/chat-ui` page for user input and display
- Frontend uses JavaScript to POST to `/chat`
- Fake AI response is displayed below the text box

### Next Steps
- Replace dummy response with OpenAI Chat API
- Style the UI (optional)
- Add persona selection
